### PR TITLE
Add more readme detail for first-time go installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Go wrapper around SSH that speaks AWS API
 
 Clone this repository and run `go install`
 
+If this is the first Go binary you're installing on your machine you'll probably need to add the folder to your PATH, like `export PATH=$PATH:$HOME/go/bin`
+
 Installation via `go get` is not currently supported; see [#3](https://github.com/adhocteam/ec2ssh/issues/3) for details
 
 ## Usage


### PR DESCRIPTION
New users may need more detail to get past `zsh: command not found: ec2ssh` if this is the first Go binary they're installing

Old users may need a reminder 🙂 